### PR TITLE
Update to 26.1.2

### DIFF
--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -1,9 +1,7 @@
 plugins {
     id 'multiloader-common'
-    id 'org.spongepowered.gradle.vanilla' version '0.2.1-SNAPSHOT'
+    id 'org.spongepowered.gradle.vanilla' version '0.3.2'
 }
-
-def useLocalYungsApi = findProject(':yungsapi') != null
 
 minecraft {
     version(mc_version)
@@ -14,12 +12,8 @@ minecraft {
 }
 
 dependencies {
-    compileOnly group:'org.spongepowered', name:'mixin', version:'0.8.5'
-    if (useLocalYungsApi) {
-        compileOnly files("libs/YungsApi-${mc_version}-Common-${yungsapi_version}.jar")
-    } else {
-        compileOnly("com.yungnickyoung.minecraft.yungsapi:YungsApi:${mc_version}-Common-${yungsapi_version}")
-    }
+    compileOnly group:'org.spongepowered', name:'mixin', version:'0.8.7'
+    compileOnly("com.yungnickyoung.minecraft.yungsapi:YungsApi-Common:${mc_version}-${yungsapi_version}")
 }
 
 configurations {
@@ -49,4 +43,14 @@ artifacts {
     commonJava sourceSets.main.java.sourceDirectories.singleFile
     commonResources sourceSets.main.resources.sourceDirectories.singleFile
     commonGeneratedResources sourceSets.generated.resources.sourceDirectories.singleFile
+}
+
+// Implement mcgradleconventions loader attribute
+def loaderAttribute = Attribute.of('io.github.mcgradleconventions.loader', String)
+['apiElements', 'runtimeElements', 'sourcesElements', 'javadocElements'].each { variant ->
+    configurations.named("$variant") {
+        attributes {
+            attribute(loaderAttribute, 'common')
+        }
+    }
 }

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -1,11 +1,9 @@
 plugins {
     id 'multiloader-loader'
-    id 'fabric-loom'
+    id 'net.fabricmc.fabric-loom'
     id 'net.darkhax.curseforgegradle'
     id 'com.modrinth.minotaur'
 }
-
-def useLocalYungsApi = findProject(':yungsapi') != null
 
 repositories {
     maven { url "https://maven.shedaniel.me/" }
@@ -20,33 +18,25 @@ repositories {
 
 dependencies {
     minecraft "com.mojang:minecraft:${mc_version}"
-    mappings loom.layered {
-        officialMojangMappings()
-        parchment("org.parchmentmc.data:parchment-${parchment_minecraft}:${parchment_version}@zip")
-    }
 
     // YUNG's API
-    if (useLocalYungsApi) {
-        modImplementation files("libs/YungsApi-${mc_version}-Fabric-${yungsapi_version}.jar")
-    } else {
-        modImplementation "com.yungnickyoung.minecraft.yungsapi:YungsApi:${mc_version}-Fabric-${yungsapi_version}"
-    }
+    implementation "com.yungnickyoung.minecraft.yungsapi:YungsApi-Fabric:${mc_version}-${yungsapi_version}"
     implementation("org.reflections:reflections:0.10.2")
     include("org.reflections:reflections:0.10.2")
 
     // Fabric
-    modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}+${mc_version}"
+    implementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
+    implementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}+${mc_version}"
 
     // For testing mod-dependent RPs
-//    modImplementation "curse.maven:travelers-titles-fabric-590990:5812595"
-//    modImplementation "curse.maven:cloth-config-348521:5729125"
+//    implementation "curse.maven:travelers-titles-fabric-590990:5812595"
+//    implementation "curse.maven:cloth-config-348521:5729125"
 
     // ClothConfig
-    modImplementation "me.shedaniel.cloth:cloth-config-fabric:${project.clothconfig_version_fabric}"
+    implementation "me.shedaniel.cloth:cloth-config-fabric:${project.clothconfig_version_fabric}"
 
     // ModMenu
-    modImplementation ("com.terraformersmc:modmenu:${project.modmenu_version_fabric}") { transitive = false }
+    implementation ("com.terraformersmc:modmenu:${project.modmenu_version_fabric}") { transitive = false }
 }
 
 loom {
@@ -77,12 +67,12 @@ loom {
 
 String[] compatibleVersions = project.compatible_versions.split(',')
 task publishCurseForgeFabric(type: net.darkhax.curseforgegradle.TaskPublishCurseForge) {
-    dependsOn(tasks.remapJar)
+    dependsOn(tasks.jar)
     apiToken = curseforgeApiKey
 
     debugMode = debug_publish.toBoolean()
 
-    def mainFile = upload(curseforge_project_id_fabric, tasks.remapJar.archiveFile)
+    def mainFile = upload(curseforge_project_id_fabric, tasks.jar.archiveFile)
     mainFile.changelogType = 'markdown'
     mainFile.changelog = file("../CHANGELOG.md").exists() ? file("../CHANGELOG.md").text : "No changelog provided"
     mainFile.releaseType = 'release'
@@ -103,7 +93,7 @@ modrinth {
     versionNumber = version
     versionName = "[${mc_version}] v${rawVersion} (Fabric)"
     versionType = "release"
-    uploadFile = remapJar
+    uploadFile = jar
     gameVersions = compatibleVersionsList
     debugMode = debug_publish.toBoolean()
     changelog = file("../CHANGELOG.md").exists() ? file("../CHANGELOG.md").text : "No changelog provided"
@@ -117,4 +107,4 @@ modrinth {
         optional.project "modmenu"
     }
 }
-tasks.modrinth.dependsOn(tasks.remapJar)
+tasks.modrinth.dependsOn(tasks.jar)

--- a/Fabric/src/main/java/com/yungnickyoung/minecraft/paxi/config/gui/PaxiModMenu.java
+++ b/Fabric/src/main/java/com/yungnickyoung/minecraft/paxi/config/gui/PaxiModMenu.java
@@ -3,7 +3,8 @@ package com.yungnickyoung.minecraft.paxi.config.gui;
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
 import com.yungnickyoung.minecraft.paxi.config.PaxiConfigFabric;
-import me.shedaniel.autoconfig.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfigClient;
+
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 
@@ -11,6 +12,6 @@ import net.fabricmc.api.Environment;
 public class PaxiModMenu implements ModMenuApi {
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
-        return parent -> AutoConfig.getConfigScreen(PaxiConfigFabric.class, parent).get();
+        return parent -> AutoConfigClient.getConfigScreen(PaxiConfigFabric.class, parent).get();
     }
 }

--- a/Fabric/src/main/java/com/yungnickyoung/minecraft/paxi/mixin/MixinModResourcePackCreatorFabric.java
+++ b/Fabric/src/main/java/com/yungnickyoung/minecraft/paxi/mixin/MixinModResourcePackCreatorFabric.java
@@ -1,11 +1,10 @@
 package com.yungnickyoung.minecraft.paxi.mixin;
 
+import java.util.function.Consumer;
+
 import com.yungnickyoung.minecraft.paxi.PaxiCommon;
 import com.yungnickyoung.minecraft.paxi.PaxiRepositorySource;
 import com.yungnickyoung.minecraft.paxi.util.IPaxiSourceProvider;
-import net.fabricmc.fabric.impl.resource.loader.ModResourcePackCreator;
-import net.minecraft.server.packs.PackType;
-import net.minecraft.server.packs.repository.Pack;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -14,7 +13,10 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.function.Consumer;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.repository.Pack;
+
+import net.fabricmc.fabric.impl.resource.pack.ModResourcePackCreator;
 
 @Mixin(ModResourcePackCreator.class)
 public class MixinModResourcePackCreatorFabric implements IPaxiSourceProvider {

--- a/Fabric/src/main/java/com/yungnickyoung/minecraft/paxi/mixin/MixinPackRepositoryFabric.java
+++ b/Fabric/src/main/java/com/yungnickyoung/minecraft/paxi/mixin/MixinPackRepositoryFabric.java
@@ -1,25 +1,5 @@
 package com.yungnickyoung.minecraft.paxi.mixin;
 
-import com.google.common.collect.ImmutableList;
-import com.yungnickyoung.minecraft.paxi.PaxiCommon;
-import com.yungnickyoung.minecraft.paxi.PaxiRepositorySource;
-import com.yungnickyoung.minecraft.paxi.client.ClientMixinUtil;
-import com.yungnickyoung.minecraft.paxi.util.IPaxiSourceProvider;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.fabric.impl.resource.loader.ModResourcePackCreator;
-import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.Util;
-import net.minecraft.server.packs.repository.Pack;
-import net.minecraft.server.packs.repository.PackRepository;
-import net.minecraft.server.packs.repository.RepositorySource;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -29,6 +9,28 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableList;
+import com.yungnickyoung.minecraft.paxi.PaxiCommon;
+import com.yungnickyoung.minecraft.paxi.PaxiRepositorySource;
+import com.yungnickyoung.minecraft.paxi.client.ClientMixinUtil;
+import com.yungnickyoung.minecraft.paxi.util.IPaxiSourceProvider;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.server.packs.repository.Pack;
+import net.minecraft.server.packs.repository.PackRepository;
+import net.minecraft.server.packs.repository.RepositorySource;
+import net.minecraft.util.Util;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.fabric.impl.resource.pack.ModResourcePackCreator;
+import net.fabricmc.loader.api.FabricLoader;
 
 /**
  * Overwrites the vanilla method for building a list of enabled packs.

--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -20,10 +20,10 @@
   },
   "depends": {
     "fabricloader": ">=${fabric_loader_version}",
-    "fabric": ">=${fabric_version}",
+    "fabric-api": ">=${fabric_version}",
     "minecraft": "${mc_version_range_fabric}",
     "java": ">=${java_version}",
-    "yungsapi": ">=${mc_version}-Fabric-${yungsapi_version}"
+    "yungsapi": ">=${mc_version}-${yungsapi_version}"
   },
   "mixins": [
     "paxi.mixins.json",

--- a/Forge/build.gradle
+++ b/Forge/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'multiloader-loader'
-    id 'net.minecraftforge.gradle' version '[6.0.25,6.2)'
-    id 'org.spongepowered.mixin'
+    id 'net.minecraftforge.gradle' version '[7.0.23,8.0)'
     id 'net.darkhax.curseforgegradle'
     id 'com.modrinth.minotaur'
 }
@@ -17,14 +16,6 @@ configurations.all {
 minecraft {
     mappings channel: 'official', version: mc_version
 
-    // Tell FG to not automtically create the reobf tasks, as we now use Official mappings at runtime, If you don't use them at dev time then you'll have to fix your reobf yourself.
-    reobf = false
-
-    // This property allows configuring Gradle's ProcessResources task(s) to run on IDE output locations before launching the game.
-    // It is REQUIRED to be set to true for this template to function.
-    // See https://docs.gradle.org/current/dsl/org.gradle.language.jvm.tasks.ProcessResources.html
-    copyIdeResources = true
-
     // Automatically enable forge AccessTransformers if the file exists
     // This location is hardcoded in Forge and can not be changed.
     // https://github.com/MinecraftForge/MinecraftForge/blob/be1698bb1554f9c8fa2f58e32b9ab70bc4385e60/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java#L123
@@ -34,10 +25,14 @@ minecraft {
     }
 
     runs {
+        configureEach {
+            args "--mixin.config=${mod_id}.mixins.json"
+            args "--mixin.config=${mod_id}_forge.mixins.json"
+        }
+
         client {
-            workingDirectory file('runs/client')
-            ideaModule "${rootProject.name}.${project.name}.main"
-            taskName 'Client'
+            workingDir.convention layout.projectDirectory.dir('runs/client')
+//            taskName 'Client'
             mods {
                 modClientRun {
                     source sourceSets.main
@@ -46,9 +41,8 @@ minecraft {
         }
 
         server {
-            workingDirectory file('runs/server')
-            ideaModule "${rootProject.name}.${project.name}.main"
-            taskName 'Server'
+            workingDir.convention layout.projectDirectory.dir('runs/server')
+//            taskName 'Server'
             mods {
                 modServerRun {
                     source sourceSets.main
@@ -57,10 +51,9 @@ minecraft {
         }
 
         data {
-            workingDirectory file('runs/data')
+            workingDir.convention layout.projectDirectory.dir('runs/data')
             args '--mod', mod_id, '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
-            ideaModule "${rootProject.name}.${project.name}.main"
-            taskName 'Data'
+//            taskName 'Data'
             mods {
                 modDataRun {
                     source sourceSets.main
@@ -72,10 +65,16 @@ minecraft {
 
 sourceSets.main.resources.srcDir 'src/generated/resources'
 
+repositories {
+    minecraft.mavenizer(it)
+    maven fg.forgeMaven
+    maven fg.minecraftLibsMaven
+}
+
 dependencies {
-    minecraft "net.minecraftforge:forge:${mc_version}-${forge_version}"
-    implementation "com.yungnickyoung.minecraft.yungsapi:YungsApi:${mc_version}-Forge-${yungsapi_version}"
-    annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
+    implementation minecraft.dependency("net.minecraftforge:forge:${mc_version}-${forge_version}")
+    implementation "com.yungnickyoung.minecraft.yungsapi:YungsApi-Forge:${mc_version}-${yungsapi_version}"
+    annotationProcessor 'org.spongepowered:mixin:0.8.7:processor'
 
     // Hack fix for now, force jopt-simple to be exactly 5.0.4 because Mojang ships that version, but some transitive dependencies request 6.0+
     // Recommended by Forge.
@@ -90,11 +89,6 @@ jar {
                 'MixinConfigs': "${mod_id}.mixins.json,${mod_id}_forge.mixins.json",
         ])
     }
-}
-
-mixin {
-    config "${mod_id}.mixins.json"
-    config "${mod_id}_forge.mixins.json"
 }
 
 // Merge the resources and classes into the same directory.

--- a/NeoForge/build.gradle
+++ b/NeoForge/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'multiloader-loader'
-    id 'net.neoforged.gradle.userdev' version '7.0.181'
+    id 'net.neoforged.gradle.userdev' version '7.1.36'
     id 'net.darkhax.curseforgegradle'
     id 'com.modrinth.minotaur'
 }
@@ -39,7 +39,10 @@ runs {
     gameTestServer {
         systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
     }
-    data {
+    serverData {
+        programArguments.addAll '--mod', project.mod_id, '--all', '--output', file('src/generated/resources/').getAbsolutePath(), '--existing', file('src/main/resources/').getAbsolutePath()
+    }
+    clientData {
         programArguments.addAll '--mod', project.mod_id, '--all', '--output', file('src/generated/resources/').getAbsolutePath(), '--existing', file('src/main/resources/').getAbsolutePath()
     }
 }
@@ -48,7 +51,7 @@ sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 dependencies {
     implementation "net.neoforged:neoforge:${neoforge_version}"
-    implementation "com.yungnickyoung.minecraft.yungsapi:YungsApi:${mc_version}-NeoForge-${yungsapi_version}"
+    implementation "com.yungnickyoung.minecraft.yungsapi:YungsApi-NeoForge:${mc_version}-${yungsapi_version}"
 }
 
 String[] compatibleVersions = project.compatible_versions.split(',')

--- a/NeoForge/src/main/java/com/yungnickyoung/minecraft/paxi/mixin/MixinPackRepositoryNeoForge.java
+++ b/NeoForge/src/main/java/com/yungnickyoung/minecraft/paxi/mixin/MixinPackRepositoryNeoForge.java
@@ -1,19 +1,5 @@
 package com.yungnickyoung.minecraft.paxi.mixin;
 
-import com.google.common.collect.ImmutableList;
-import com.yungnickyoung.minecraft.paxi.PaxiCommon;
-import com.yungnickyoung.minecraft.paxi.PaxiRepositorySource;
-import net.minecraft.Util;
-import net.minecraft.server.packs.repository.Pack;
-import net.minecraft.server.packs.repository.PackRepository;
-import net.minecraft.server.packs.repository.RepositorySource;
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -23,6 +9,21 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableList;
+import com.yungnickyoung.minecraft.paxi.PaxiCommon;
+import com.yungnickyoung.minecraft.paxi.PaxiRepositorySource;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.server.packs.repository.Pack;
+import net.minecraft.server.packs.repository.PackRepository;
+import net.minecraft.server.packs.repository.RepositorySource;
+import net.minecraft.util.Util;
 
 /**
  * Overwrites the vanilla method for building a list of enabled packs.

--- a/NeoForge/src/main/java/com/yungnickyoung/minecraft/paxi/services/NeoForgePlatformHelper.java
+++ b/NeoForge/src/main/java/com/yungnickyoung/minecraft/paxi/services/NeoForgePlatformHelper.java
@@ -16,6 +16,6 @@ public class NeoForgePlatformHelper implements IPlatformHelper {
 
     @Override
     public boolean isDevelopmentEnvironment() {
-        return !FMLLoader.isProduction();
+        return !FMLLoader.getCurrent().isProduction();
     }
 }

--- a/NeoForge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/NeoForge/src/main/resources/META-INF/neoforge.mods.toml
@@ -25,7 +25,7 @@ issueTrackerURL="https://github.com/yungnickyoung/Paxi/issues"
 
 [[dependencies.${mod_id}]]
     modId="yungsapi"
-    versionRange="[${mc_version}-NeoForge-${yungsapi_version},)"
+    versionRange="[${mc_version}-${yungsapi_version},)"
     type="required"
     ordering="NONE"
     side="BOTH"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'fabric-loom' version '1.10-SNAPSHOT' apply false
-    id "org.jetbrains.gradle.plugin.idea-ext" version "1.1.7" // required for NeoGradle
+    id 'net.fabricmc.fabric-loom' version '1.16-SNAPSHOT' apply false
+    id "org.jetbrains.gradle.plugin.idea-ext" version "1.4.1" // required for NeoGradle
     id 'org.spongepowered.mixin' version '0.7-SNAPSHOT' apply false
     id 'net.darkhax.curseforgegradle' version "${curseforgegradle_version}" apply false // curseforge publishing
     id "com.modrinth.minotaur" version "2.+" apply false // modrinth publishing

--- a/buildSrc/src/main/groovy/multiloader-common.gradle
+++ b/buildSrc/src/main/groovy/multiloader-common.gradle
@@ -27,15 +27,6 @@ repositories {
         }
         filter { includeGroupAndSubgroups("org.spongepowered") }
     }
-    exclusiveContent {
-        forRepository {
-            maven {
-                name = 'ParchmentMC'
-                url = 'https://maven.parchmentmc.org/'
-            }
-        }
-        filter { includeGroup('org.parchmentmc.data') }
-    }
     maven {
         url "https://www.cursemaven.com"
         content {
@@ -49,19 +40,6 @@ repositories {
     flatDir {
         dirs 'libs'
     }
-}
-
-// Declare capabilities on the outgoing configurations.
-// Read more about capabilities here: https://docs.gradle.org/current/userguide/component_capabilities.html#sec:declaring-additional-capabilities-for-a-local-component
-['apiElements', 'runtimeElements', 'sourcesElements', 'javadocElements'].each { variant ->
-    configurations."$variant".outgoing {
-        capability("$group:${base.archivesName.get()}:$version")
-        capability("$group:$mod_id-${project.name}-${mc_version}:$version")
-        capability("$group:$mod_id:$version")
-    }
-//    publishing.publications.configureEach {
-//        suppressPomMetadataWarningsFor(variant)
-//    }
 }
 
 sourcesJar {

--- a/buildSrc/src/main/groovy/multiloader-loader.gradle
+++ b/buildSrc/src/main/groovy/multiloader-loader.gradle
@@ -16,8 +16,9 @@ configurations {
 
 dependencies {
     compileOnly(project(':Common')) {
-        capabilities {
-            requireCapability "$group:$mod_id"
+        def loaderAttribute = Attribute.of('io.github.mcgradleconventions.loader', String)
+        attributes {
+            attribute(loaderAttribute, 'common')
         }
     }
     commonJava project(path: ':Common', configuration: 'commonJava')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project
 version=5.1.3
-java_version=21
+java_version=25
 
 # Metadata
 mod_name=Paxi
@@ -11,15 +11,13 @@ mod_description=Drag-and-drop your data packs and let Paxi do the rest! Global d
 mod_credits=Thanks so much to all my patrons!
 license=LGPLv3
 maven_group=com.yungnickyoung.minecraft.paxi
-mc_version=1.21.1
-mc_version_range=[1.21, 1.22)
-mc_version_range_fabric=>=1.21
-parchment_minecraft=1.21
-parchment_version=2024.06.23
+mc_version=26.1.2
+mc_version_range=[26.1, 26.2)
+mc_version_range_fabric=~26.1
 
 # CurseForge/Modrinth Publishing
 curseforgegradle_version=1.1.15
-compatible_versions=1.21,1.21.1
+compatible_versions=26.1,26.1.1,26.1.2
 curseforge_project_id_forge=515708
 curseforge_project_id_fabric=418881
 curseforge_project_id_neoforge=1015157
@@ -30,18 +28,18 @@ debug_publish=true
 yungsapi_version=5.1.4
 
 # Forge
-forge_version=52.0.17
-forge_loader_version_range=[51,)
+forge_version=64.0.8
+forge_loader_version_range=[62,)
 
 # Fabric
-fabric_version=0.102.0
-fabric_loader_version=0.15.11
-clothconfig_version_fabric=15.0.140
-modmenu_version_fabric=11.0.2
+fabric_version=0.150.0
+fabric_loader_version=0.18.4
+clothconfig_version_fabric=26.1.154
+modmenu_version_fabric=18.0.0-beta.1
 
 # NeoForge
-neoforge_version=21.1.66
-neoforge_version_range=[21.0.0,)
+neoforge_version=26.1.2.70-beta
+neoforge_version_range=[26.1.0,)
 neoforge_loader_version_range=[4,)
 
 # Credentials for publishing. Gets overwritten with global gradle.properties.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,17 +2,9 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         mavenCentral()
-        exclusiveContent {
-            forRepository {
-                maven {
-                    name = 'Fabric'
-                    url = uri("https://maven.fabricmc.net")
-                }
-            }
-            filter {
-                includeGroup("net.fabricmc")
-                includeGroup("fabric-loom")
-            }
+        maven {
+            name = 'Fabric'
+            url = uri("https://maven.fabricmc.net")
         }
         exclusiveContent {
             forRepository {
@@ -52,8 +44,19 @@ pluginManagement {
 }
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
+
+if (file("yungsapi").exists()) {
+    includeBuild(".")
+    includeBuild("yungsapi") {
+        dependencySubstitution {
+            substitute(module("com.yungnickyoung.minecraft.yungsapi:YungsApi-NeoForge")).using(project(":NeoForge"))
+            substitute(module("com.yungnickyoung.minecraft.yungsapi:YungsApi-Fabric")).using(project(":Fabric"))
+            substitute(module("com.yungnickyoung.minecraft.yungsapi:YungsApi-Common")).using(project(":Common"))
+        }
+    }
 }
 
 rootProject.name = 'paxi'
-include("Common", "Fabric", "Forge", "NeoForge")
+include("Common", "Fabric", "NeoForge")


### PR DESCRIPTION
Depends on YUNG-GANG/YUNGs-API#102.
Full update to 26.1.2, disabled Forge module since it's also disabled in YUNG's API. Unsure if it should be deleted or not. Also adds dependency on YUNG's API via dependency substitution when not published to any Maven repositories.

This does not share the `ProjectName-Loader:MCVersion-Version` formatting change like the YUNG's API PR does, although it probably should.